### PR TITLE
email: remove `json-stringify-safe` to boost perf

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert');
+const benchmark = require('benchmark');
+const maskme = require('../');
+
+const suite = new benchmark.Suite();
+
+suite.add('maskEmail (object)', () => {
+    maskme.maskEmail({ a: 'helloworld.gmail.com' });
+});
+
+suite.add('maskEmail (hit)', () => {
+    maskme.maskEmail('helloworld@gmail.com');
+});
+
+suite.add('maskEmail (miss)', () => {
+    maskme.maskEmail('helloworld.gmail.com');
+});
+
+suite
+    .on('cycle', (event) => {
+        console.log(String(event.target));
+        if (event.target.error)
+            console.error(event.target.error);
+    })
+    .run();

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,48 +1,50 @@
 'use strict';
 
 var utilis = require('core-util-is'),
-    querystring = require('querystring'),
-    stringify = require('json-stringify-safe');
+    querystring = require('querystring');
 
 var EmailPattern = RegExp(/[a-z0-9_+&*-]+(?:\.[a-z0-9_+&*-]+)*@(?:[a-z0-9-]+\.)+[a-z]{2,7}/ig);
 
-function maskEmail(data) {
-    var datastr = data,
-        isObject = false,
-        mightHaveReplaced = false;
+function maskCircular(data, seen) {
+  if (utilis.isString(data)) {
+      if (data.indexOf('@') !== -1 || data.indexOf('%40') !== -1) {
+          var datastr = querystring.unescape(data);
+          datastr = datastr.replace(EmailPattern, 'xxx@xxx.xxx');
+          return datastr;
+      }
+      return data;
+  } else if (!utilis.isObject(data)) {
+      return data;
+  }
 
-    if (utilis.isObject(data)) {
-        datastr = stringify(data);
-        isObject = true;
-    }
+  if (seen === null) {
+      seen = [ data ];
+  } else {
+      if (seen.indexOf(data) !== -1)
+          return '[Circular]';
+      seen.push(data);
+  }
 
-    //only run regex if dataString contains @ or %40 (encoded @)
-    if (utilis.isString(datastr) && (datastr.indexOf('@') !== -1 || datastr.indexOf('%40') !== -1)) {
-        datastr = querystring.unescape(datastr);
-        datastr = datastr.replace(EmailPattern, 'xxx@xxx.xxx');
-        mightHaveReplaced = true;
-    }
+  if (Array.isArray(data)) {
+      var copy = new Array(data.length);
+      for (var i = 0; i < data.length; i++)
+          copy[i] = maskCircular(data[i], seen);
+      return copy;
+  }
 
-    if (isObject) {
-        if (mightHaveReplaced) {
-            datastr = parseJSON(datastr);
-        } else {
-            datastr = data;
-        }
+  var copy = {};
+  var keys = Object.keys(data);
+  for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var value = data[key];
 
-    }
-
-    return datastr;
+      copy[key] = maskCircular(value, seen);
+  }
+  return copy;
 }
 
-function parseJSON(value) {
-    var obj;
-    try {
-        obj = JSON.parse(value);
-    } catch (e) {
-        //No op
-    }
-    return obj;
+function maskEmail(data) {
+    return maskCircular(data, null);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "core-util-is": "^1",
-    "json-stringify-safe": "^5"
+    "core-util-is": "^1"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "eslint": "^2",
     "mocha": "^2"
   }

--- a/test/test-email.js
+++ b/test/test-email.js
@@ -37,6 +37,42 @@ describe('email mark', function () {
         });
     });
 
+    it('email in circular object', function () {
+        var obj = { a: "b", c: null, email: "helloworld@gmail.com" };
+        obj.c = obj;
+
+        var masked = maskme.maskEmail(obj);
+        assert.deepEqual(masked, {
+          a: "b",
+          c: "[Circular]",
+          email: "xxx@xxx.xxx"
+        });
+    });
+
+    it('email in circular array', function () {
+        var arr = [ "b", null, "email@email.com" ];
+        arr[1] = arr;
+
+        var masked = maskme.maskEmail(arr);
+        assert.deepEqual(masked, [
+          "b",
+          "[Circular]",
+          "xxx@xxx.xxx"
+        ]);
+    });
+
+    it('email in nested circular object', function () {
+        var hit = { email: "helloworld@gmail.com" };
+        var obj = { a: "b", c: { hit: hit }, d: { e: { hit: hit } } };
+
+        var masked = maskme.maskEmail(obj);
+        assert.deepEqual(masked, {
+          a: "b",
+          c: { hit: { email: "xxx@xxx.xxx" } },
+          d: { e: { hit: "[Circular]" } }
+        });
+    });
+
     it('-ive tests', function () {
         var array = new Array(10240);
         var allA = array.join('a.com ');


### PR DESCRIPTION
Boost performance by walking through objects manually.

Ops/sec before the patch:

    maskEmail (object) x 943,982 ops/sec ±0.52% (96 runs sampled)
    maskEmail (hit) x 1,063,417 ops/sec ±0.63% (90 runs sampled)
    maskEmail (miss) x 12,863,284 ops/sec ±0.96% (92 runs sampled)

After the patch:

    maskEmail (object) x 5,103,084 ops/sec ±1.75% (86 runs sampled)
    maskEmail (hit) x 1,068,074 ops/sec ±0.59% (92 runs sampled)
    maskEmail (miss) x 12,219,161 ops/sec ±0.80% (92 runs sampled)

--------

This probably needs a major version bump. The `[Circular]` is going to be used for all circular objects, regardless of their position in the original object.