### PR TITLE
use Object.getOwnPropertyNames for error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - use Object.getOwnPropertyNames for error objects
  - updating test dependencies
 
 ### 1.0.0

--- a/lib/email.js
+++ b/lib/email.js
@@ -35,7 +35,12 @@ function maskCircular(data, seen) {
       return copy;
   }
 
-  var keys = Object.keys(data);
+  var keys;
+  if (data instanceof Error) {
+      keys = Object.getOwnPropertyNames(data);
+  } else {
+      keys = Object.keys(data);
+  }
   for (i = 0; i < keys.length; i++) {
       var key = keys[i];
       var value = data[key];

--- a/test/test-email.js
+++ b/test/test-email.js
@@ -85,4 +85,16 @@ describe('email mark', function () {
         assert(maskme.maskEmail(allA).indexOf('@gmail.com') === -1);
     });
 
+    it('error', function(){
+        var error = new Error("error");
+        var masked = maskme.maskEmail(error);
+        assert.equal(masked.message, "error");
+    });
+
+    it('error with email', function(){
+        var error = new Error("helloworld@gmail.com");
+        var masked = maskme.maskEmail(error);
+        assert.equal(masked.message, "xxx@xxx.xxx");
+    })
+
 });


### PR DESCRIPTION
Error objects will return empty if they are passed to `maskEmail()`. This is because they are non-enumerable and properties of non enumerable objects will not show up if you use `Object.keys()`. 

I changed the code to check if the object is an error object. If it is, i used `Object.getOwnPropertyNames()` to fetch the properties instead. 

Tested this locally, and included two unit tests. 